### PR TITLE
Always return a boolean value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = isPromise;
 
 function isPromise(obj) {
-  return obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
 }

--- a/test.js
+++ b/test.js
@@ -14,12 +14,12 @@ describe('calling isPromise', function () {
   });
   describe('with null', function () {
     it('returns false', function () {
-      assert(!isPromise(null));
+      assert(isPromise(null) === false);
     });
   });
   describe('with undefined', function () {
     it('returns false', function () {
-      assert(!isPromise(undefined));
+      assert(isPromise(undefined) === false);
     });
   });
   describe('with a number', function () {


### PR DESCRIPTION
I hit a snag writing `isPromise(undefinedThing) === false`, so I added a double-bang to the initial check to ensure that a boolean value is always returned.