### PR TITLE
catch exploding 'then' get

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 module.exports = isPromise;
 
 function isPromise(obj) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+  try {
+    return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+  }
+  catch ( err ) {
+    return false;
+  }
 }

--- a/test.js
+++ b/test.js
@@ -53,4 +53,12 @@ describe('calling isPromise', function () {
       assert(!isPromise([true]));
     });
   });
+  describe('with an exploding "then"', function () {
+    it('returns false', function () {
+      var exploder = {
+        get then() { throw new Error("Boom go the dynamit!"); }
+      };
+      assert(!isPromise(exploder));
+    });
+  });
 });


### PR DESCRIPTION
having just implemented an A+ library, I got very familiar with the compliance tests.  One of those tests accounts for the 'then' getter exploding (it also seems to require that the getter is called only once, but I digress).  my thought is that if a Promise immediately rejects when the 'then' getter explodes, then the `isPromise(x)` method should probably treat it as if it weren't a Promise.

That said, if a getter is exploding, somebody's code has bigger problems, but at least this method won't be one of them.

Course, I could be wrong.
