### PR TITLE
ci: remove common-env context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,17 +60,14 @@ workflows:
 
       - publish-dry-run:
           <<: *only_master
-          context: common-env
 
       - publish-approval:
           type: approval
-          context: common-env
           requires:
             - publish-dry-run
 
       - publish:
           <<: *only_master
-          context: common-env
           requires:
             - node-6
             - node-8


### PR DESCRIPTION
This was pulling in a token that did not have the correct permissions