### PR TITLE
chore: remove .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-component
-build
-node_modules
-test.js
-component.json
-.gitignore


### PR DESCRIPTION
It is overriden by the "files" property anyway, and gives the wrong impression about what will be included by default.