### PR TITLE
Simplify evaluation

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,5 @@ module.exports = isPromise;
 module.exports.default = isPromise;
 
 function isPromise(obj) {
-  return !!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+  return 'function' == typeof (obj && obj.then);
 }


### PR DESCRIPTION
The purpose of this change is to simplify the evaluation of `obj` as a Promise, based on the current assertion (object contains a `function` called `then`)