### PR TITLE
add prepublishOnly hook which auto-runs npm run test on-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Test whether an object looks like a promises-a+ promise",
   "main": "./index.js",
   "scripts": {
+    "prepublishOnly": "npm run test",
     "test": "node test"
   },
   "files": [


### PR DESCRIPTION
Helps mitigate any potential errors with running `npm publish` before the tests -- not sure if that is the reason for anything recently or not, but it could just be a good idea to have that trigger automatically vs an internal script. 

(Thanks ✌)