### PR TITLE
test: simplify esm test

### DIFF
--- a/test.mjs
+++ b/test.mjs
@@ -1,11 +1,6 @@
-var assert = require('assert');
-var isPromise = require('./');
+import assert from 'assert';
+import isPromise from 'is-promise';
 
-// `.then` methods on primative types should
-// not make them count as promises
-String.prototype.then = () => {};
-Number.prototype.then = () => {};
-Boolean.prototype.then = () => {};
 
 assert(isPromise(null) === false);
 assert(isPromise(undefined) === false);
@@ -32,12 +27,4 @@ const fn = () => {};
 fn.then = () => {};
 assert(isPromise(fn) === true);
 
-console.log('common.js tests passed')
-
-try {
-  require('is-promise');
-  const result = require('child_process').spawnSync('node', ['--experimental-modules', 'test.mjs'], {cwd: __dirname, stdio: 'inherit'});
-  if (result.status) process.exit(result.status);
-} catch (e) {
-  if (e.code !== 'MODULE_NOT_FOUND') throw e;
-}
+console.log('ES Modules tests passed')


### PR DESCRIPTION
This only maintains testing for esm, not the typescript support.
It also does not make any changes to the existing CircleCI setup.

With self-referential modules we can simply "require" or "import"
a module from within itself. This is also a decent way to sniff
for support for ESM, as all modern versions of Node.js that support
ESM have this functionality.

Feel free to let me know if you want me to remove the `test-import`
directory or if you want to update circleCI.